### PR TITLE
Tweak mobile style for TopBar

### DIFF
--- a/src/components/TopBarView.tsx
+++ b/src/components/TopBarView.tsx
@@ -43,13 +43,13 @@ const useStyles = makeStyles(theme => {
     select: {
       backgroundColor: is_bright ? "#657ce9" : "#9095b2", //9297b3", //9FA4C2",
       color: theme.palette.background.paper,
-      paddingLeft: 35,
+      paddingLeft: 25,
       marginRight: 5,
       marginLeft: 15,
       height: 60,
       fontWeight: 400,
       fontSize: "1.0rem",
-      paddingTop: 4,
+      paddingTop: 6,
       paddingBottom: 7,
       [theme.breakpoints.down('sm')]: {
         paddingLeft: 15,

--- a/src/components/TopBarView.tsx
+++ b/src/components/TopBarView.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles(theme => {
         marginLeft: 10,
         fontSize: "0.9rem",
       },
+      [theme.breakpoints.down(400)]: {
+        maxWidth: 160,
+      }
       //borderBottom: "1px solid " + theme.palette.background.default,
     }
 })})

--- a/src/components/TopBarView.tsx
+++ b/src/components/TopBarView.tsx
@@ -43,14 +43,20 @@ const useStyles = makeStyles(theme => {
     select: {
       backgroundColor: is_bright ? "#657ce9" : "#9095b2", //9297b3", //9FA4C2",
       color: theme.palette.background.paper,
-      paddingLeft: theme.breakpoints.down('sm') ? 15 : 35,
-      marginRight: theme.breakpoints.down('sm') ? -5 : 5,
-      marginLeft: theme.breakpoints.down('sm') ? 10 : 15,
+      paddingLeft: 35,
+      marginRight: 5,
+      marginLeft: 15,
       height: 60,
       fontWeight: 400,
       fontSize: "1.0rem",
       paddingTop: 4,
       paddingBottom: 7,
+      [theme.breakpoints.down('sm')]: {
+        paddingLeft: 15,
+        marginRight: -5,
+        marginLeft: 10,
+        fontSize: "0.9rem",
+      },
       //borderBottom: "1px solid " + theme.palette.background.default,
     }
 })})


### PR DESCRIPTION
Fixes a few issues

Mobile-specific styles for the TopBar dropdown were applying to all screen sizes
Material UI's `theme.breakpoints.down('sm')` returns a media query string instead of a boolean, which is always truthy
I fixed its usage

Made the font size smaller on mobile

On screens narrower than 400 CSS pixels, the dropdown is now cut off to prevent layout from overflowing
e.g. iPhone SE 2nd gen
before:
![image](https://github.com/onionhoney/roux-trainers/assets/50253028/2090961f-c5b0-4493-9bc7-66507c30ff60)
after:
![image](https://github.com/onionhoney/roux-trainers/assets/50253028/b9e01bbe-5fb2-439c-85b9-607350eff85a)
