### PR TITLE
Add support to 'lefty handed' Roux

### DIFF
--- a/src/Config.tsx
+++ b/src/Config.tsx
@@ -32,6 +32,7 @@ export type Config = {
     hyperOriSelector: Selector;
     ollcpCaseSelector: Selector;
     orientationSelector: Selector;
+    handednessSelector: Selector;
     fbdrSelector: Selector;
     fsSelector: Selector;
     fbdrPosSelector1: Selector;
@@ -78,6 +79,12 @@ Explanation:
 These modes apply different constraints on your FB state.
 [Hard] means there's no free pair AND no edges attached to the L center.
 [Hard over x2y] means it's hard for all FBs over the x2y orientations. To see solutions, paste them into the FB analyzer.`
+
+const handednessAnnotation = `
+Explanation:
+Left-handed Roux is the mirror image of regular Roux: the first block is built at DR
+instead of DL, and the second block at DL. Scrambles, solutions and the virtual cube
+are all mirrored accordingly.`
 
 const initialLevels = {
     fbdrLevelSelector: ({
@@ -195,6 +202,13 @@ export const initialConfig : Config = (() => {
             names: ollcp_alg_names,
             flags: Array(ollcp_alg_names.length).fill(1),
             kind: "ollcp_case"
+        }),
+        handednessSelector: new Selector({
+            label: "Handedness",
+            names: ["Right-handed", "Left-handed"],
+            flags: [1, 0],
+            kind: "handedness",
+            annotation: handednessAnnotation
         }),
         orientationSelector: new Selector({
             label: "Color Scheme (U-F)",

--- a/src/components/BlockTrainerView.tsx
+++ b/src/components/BlockTrainerView.tsx
@@ -16,6 +16,7 @@ import IconButton from '@mui/material/IconButton';
 
 
 import { FaceletCube, Mask, MoveSeq } from '../lib/CubeLib';
+import { isLeftHanded, mirrorAlg, mirrorMask } from '../lib/Handedness';
 
 import { AppState,  Action, FavCase, Mode} from "../Types";
 import 'typeface-roboto-mono';
@@ -183,12 +184,20 @@ function getHelperTextForMode(mode: Mode) {
 
 function BlockTrainerView(props: { state: AppState, dispatch: React.Dispatch<Action> } ) {
     let { state, dispatch } = props
-    let cube = state.cube.state
     let classes = useStyles()
 
-    let facelet = FaceletCube.from_cubie(cube, getMask(state))
+    const lefty = isLeftHanded(state.mode, state.config)
+    let cube = lefty ? state.cube.state.mirror() : state.cube.state
 
-    let desc : CaseDesc[] = state.case.desc.length ? state.case.desc :
+    let facelet = FaceletCube.from_cubie(cube, lefty ? mirrorMask(getMask(state)) : getMask(state))
+
+    let caseDesc : CaseDesc[] = lefty ? state.case.desc.map(d => ({
+        ...d,
+        algs: d.algs.map(mirrorAlg),
+        setup: d.setup === undefined ? undefined : mirrorAlg(d.setup)
+    })) : state.case.desc
+
+    let desc : CaseDesc[] = caseDesc.length ? caseDesc :
        [ { algs: [""], setup:"Press next for new case", id: "", kind: ""} ]
 
     let spaceButtonText = (state.name === "hiding") ? "Reveal" : "Next"
@@ -246,7 +255,7 @@ function BlockTrainerView(props: { state: AppState, dispatch: React.Dispatch<Act
       const case_ : FavCase = {
         mode: state.mode,
         solver: state.case.desc.map(x => x.kind),
-        setup: setup || ""
+        setup: state.case.desc[0].setup || ""
       }
       if (!favSelected){
         setFav(true)
@@ -455,6 +464,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
         </Box>
 
         <MultiSelect {...{state, dispatch, select: "ssPosSelector", options: {manipulators: DRManip} }}> </MultiSelect>
+        <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
         <ColorPanel {...{state, dispatch}} />
       </Box>
 
@@ -489,6 +499,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
 
         <MultiSelect {...{state, dispatch, select: pos1, options: {manipulators: LPEdgeManip} }}> </MultiSelect>
         <MultiSelect {...{state, dispatch, select: pos3, options: {manipulators: LPEdgeManip} }}> </MultiSelect>
+        <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
         <ColorPanel {...{state, dispatch}} />
       </Box>
 
@@ -508,6 +519,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
           <SingleSelect {...{state, dispatch, select: "moveCountHint"}}> </SingleSelect>
           <SingleSelect {...{state, dispatch, select: "showCube"}}> </SingleSelect>
 
+          <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
           <ColorPanel {...{state, dispatch}} />
         </Box>
 
@@ -528,6 +540,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
           <SingleSelect {...{state, dispatch, select: "moveCountHint"}}> </SingleSelect>
           <SingleSelect {...{state, dispatch, select: "showCube" }}> </SingleSelect>
 
+          <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
           <ColorPanel {...{state, dispatch}} />
         </Box>
 
@@ -548,6 +561,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
           <SingleSelect {...{state, dispatch, select: "moveCountHint"}}> </SingleSelect>
           <SingleSelect {...{state, dispatch, select: "showCube" }}> </SingleSelect>
 
+          <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
           <ColorPanel {...{state, dispatch}} />
         </Box>
 
@@ -568,6 +582,7 @@ function ConfigPanelGroup(props: {state: AppState, dispatch: React.Dispatch<Acti
           <SingleSelect {...{ state, dispatch, select: select3 }}> </SingleSelect>
           {/* <SingleSelect {...{state, dispatch, select: "evaluator"}}> </SingleSelect> */}
           <SingleSelect {...{state, dispatch, select: "moveCountHint"}}> </SingleSelect>
+          <SingleSelect {...{state, dispatch, select: "handednessSelector"}}> </SingleSelect>
           <ColorPanel {...{state, dispatch}} />
         </Box>
 

--- a/src/components/FavListView.tsx
+++ b/src/components/FavListView.tsx
@@ -16,6 +16,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import AddIcon from '@mui/icons-material/Add';
 import { AppState, Action, FavCase } from '../Types';
 import { all_solvers } from '../lib/CachedSolver';
+import { isLeftHanded, mirrorScramble } from '../lib/Handedness';
 
 
 const useStyles = makeStyles(theme => ({
@@ -38,7 +39,10 @@ function parseAddString(state: AppState, s : string) : [ FavCase[], boolean] {
     let cols = line.split(',')
     if (cols.length !== 2) continue
     let solver = cols[0].trim().split("|")
-    let setup = cols[1].trim()
+    // favorites are stored right-handed; a left-handed user types left-handed setups
+    let setup = isLeftHanded(state.mode, state.config)
+      ? mirrorScramble(cols[1].trim())
+      : cols[1].trim()
 
     if (solver.every(x => allSolvers.has(x))) {
       let case_ : FavCase = {
@@ -57,6 +61,8 @@ export default function FavListView(props: { state: AppState, dispatch: React.Di
   const {state, dispatch} = props
   const classes = useStyles();
   const favList = state.favList.filter(c => c.mode === state.mode)
+  const lefty = isLeftHanded(state.mode, state.config)
+  const displaySetup = (setup: string) => lefty ? mirrorScramble(setup) : setup
 
   const play = (i: number) => {
     dispatch({ type: "favList", content: [ favList[i] ], action: "replay" })
@@ -153,7 +159,7 @@ export default function FavListView(props: { state: AppState, dispatch: React.Di
                   {/* padding=checkbox <Checkbox></Checkbox> */}
 
                 <TableCell align="center">
-                { value.solver.join("|") + "," + value.setup }
+                { value.solver.join("|") + "," + displaySetup(value.setup) }
                 </TableCell>
                 <TableCell align="center">
                   <IconButton onFocus={(e: { target: { blur: () => void; }; }) => e.target.blur() } onClick={() => play(i)}

--- a/src/lib/CubeLib.tsx
+++ b/src/lib/CubeLib.tsx
@@ -8,6 +8,14 @@ const C_MOD = 3;
 const E_MOD = 2;
 const T_MOD = 1;
 
+// M-plane reflection: piece index i maps to mirror_*_map[i].
+// corners: UFL<->URF, ULB<->UBR, DLF<->DFR, DBL<->DRB
+const mirror_cp_map = [3, 2, 1, 0, 7, 6, 5, 4]
+// edges: UL<->UR, DL<->DR, FL<->FR, BL<->BR
+const mirror_ep_map = [0, 3, 2, 1, 4, 7, 6, 5, 11, 10, 9, 8]
+// centers: L<->R
+const mirror_tp_map = [0, 1, 2, 3, 5, 4]
+
 export class CubieCube {
     cp: number[] = [];
     co: number[] = [];
@@ -263,6 +271,26 @@ export class CubieCube {
         return perm_correct && ori_correct
     }
 
+    // Reflection through the M plane (swaps the L and R halves of the cube).
+    // Used to turn a right-handed Roux case into its left-handed counterpart.
+    mirror() : CubieCube {
+        let cp = Array(8).fill(0), co = Array(8).fill(0)
+        let ep = Array(12).fill(0), eo = Array(12).fill(0)
+        let tp = Array(6).fill(0)
+        for (let i = 0; i < 8; i++) {
+            cp[mirror_cp_map[i]] = mirror_cp_map[this.cp[i]]
+            co[mirror_cp_map[i]] = (C_MOD - this.co[i]) % C_MOD
+        }
+        for (let i = 0; i < 12; i++) {
+            ep[mirror_ep_map[i]] = mirror_ep_map[this.ep[i]]
+            eo[mirror_ep_map[i]] = this.eo[i]
+        }
+        for (let i = 0; i < 6; i++) {
+            tp[mirror_tp_map[i]] = mirror_tp_map[this.tp[i]]
+        }
+        return new CubieCube({cp, co, ep, eo, tp})
+    }
+
     changeBasis(s: MoveSeq) {
         // only take x and y for now
         let facelet_mapping = this._to_facelet_mapping(corners_coord, edges_coord, centers_coord)
@@ -389,6 +417,23 @@ export class Move {
         return moves_dict
     }
     static all: {[key: string]: Move} = Move.generate_base_moves();
+
+    // Name of this move reflected through the M plane.
+    // Reflecting reverses the turn direction, except around the L-R axis, where the
+    // reflection also flips the axis so the spatial direction survives 
+    static mirror_name(name: string) : string {
+        if (name === "id" || name.length === 0) return name
+        if (name[0] === "M" || name[0] === "x") return name
+        const swap : {[key: string]: string} = { "R": "L", "L": "R", "r": "l", "l": "r" }
+        const face = swap[name[0]] || name[0]
+        const suffix = name.slice(1)
+        const mirrored_suffix = (suffix === "'") ? "" : (suffix === "2") ? "2" : "'"
+        return face + mirrored_suffix
+    }
+
+    mirror(): Move {
+        return Move.all[Move.mirror_name(this.name)]
+    }
 
     inv(): Move {
         let name: string
@@ -527,6 +572,10 @@ export class MoveSeq {
     inv() {
         let moves: Move[] = this.moves.slice(0).reverse().map(x => x.inv()).flat()
         return new MoveSeq(moves)
+    }
+
+    mirror() {
+        return new MoveSeq(this.moves.map(x => x.mirror()))
     }
 
     slice(n: number) {
@@ -772,6 +821,23 @@ function mask_copy (m: Mask) {
         cp: [...m.cp],
         ep: [...m.ep]
     }
+}
+
+function mask_mirror (m: Mask) : Mask {
+    const permute = (arr: number[] | undefined, map: number[]) =>
+        arr && map.map((_, i) => arr[map.indexOf(i)])
+    return {
+        co: permute(m.co, mirror_cp_map),
+        eo: permute(m.eo, mirror_ep_map),
+        tp: permute(m.tp, mirror_tp_map),
+        cp: permute(m.cp, mirror_cp_map)!,
+        ep: permute(m.ep, mirror_ep_map)!
+    }
+}
+
+function mirror_alg_string (s: string) : string {
+    return s.replace(/[A-Za-z][2']?/g, (token) =>
+        Move.all[token] ? Move.mirror_name(token) : token)
 }
 
 const lse_mask: Mask = {
@@ -1182,7 +1248,8 @@ export class ColorScheme extends Storage {
 let Mask = {
     lse_mask, fs_back_mask, fs_front_mask, fbdr_mask, fb_mask, f2b_mask, sb_mask, cmll_mask, ss_front_mask, ss_back_mask,
     ssdp_front_mask, ssdp_back_mask, ssdp_both_mask, empty_mask, dl_solved_mask, bl_solved_mask, solved_mask, zhouheng_mask, lse_4c_mask,
-    copy: mask_copy
+    copy: mask_copy,
+    mirror: mask_mirror
 }
 
-export { FaceletCube, CubeUtil, Mask }
+export { FaceletCube, CubeUtil, Mask, mirror_alg_string }

--- a/src/lib/Handedness.tsx
+++ b/src/lib/Handedness.tsx
@@ -1,0 +1,23 @@
+import { Config } from "../Config";
+import { Mode } from "../Types";
+import { MaskT, Mask, MoveSeq, mirror_alg_string } from "./CubeLib";
+
+// Modes built around the FB-at-DL / SB-at-DR convention, and therefore mirrorable.
+const handedness_modes = new Set<Mode>(["fb", "fbdr", "fs", "fsdr", "ss", "fbss"])
+
+export function isLeftHanded(mode: Mode, config: Config): boolean {
+    return handedness_modes.has(mode) &&
+        config.handednessSelector?.getActiveName() === "Left-handed"
+}
+
+export function mirrorAlg(alg: string): string {
+    return mirror_alg_string(alg)
+}
+
+export function mirrorScramble(scramble: string): string {
+    return new MoveSeq(scramble).mirror().toString().trim()
+}
+
+export function mirrorMask(mask: MaskT): MaskT {
+    return Mask.mirror(mask)
+}

--- a/src/lib/LeftyFlow.test.tsx
+++ b/src/lib/LeftyFlow.test.tsx
@@ -1,0 +1,79 @@
+import { getInitialState } from '../reducers/InitialState'
+import { reducer } from '../reducers/Reducer'
+import { CubieCube, CubeUtil, Mask, MoveSeq } from './CubeLib'
+import { isLeftHanded, mirrorAlg, mirrorMask } from './Handedness'
+import { AppState } from '../Types'
+
+function lefty(state: AppState): AppState {
+    return reducer(state, { type: "config", content: {
+        handednessSelector: state.config.handednessSelector.setFlags([0, 1])
+    }})
+}
+
+test('fb mode, left-handed: shown scramble + shown solution build a right-hand block', () => {
+    let state = lefty(getInitialState("fb"))
+    expect(isLeftHanded(state.mode, state.config)).toBe(true)
+
+    for (let i = 0; i < 3; i++) {
+        state = reducer(state, { type: "key", content: "#space" })   // next case
+
+        // exactly what BlockTrainerView renders
+        const shownSetup = mirrorAlg(state.case.desc[0].setup!)
+        const shownAlgs = state.case.desc[0].algs.map(mirrorAlg)
+        const shownMask = mirrorMask(Mask.fb_mask)
+
+        expect(shownAlgs.length).toBeGreaterThan(0)
+        for (const alg of shownAlgs) {
+            const cube = new CubieCube().apply(shownSetup).apply(new MoveSeq(alg))
+            expect([alg, CubeUtil.is_solved(cube, shownMask)]).toEqual([alg, true])
+        }
+        // the cube drawn for the user matches the scramble on the pieces it reveals
+        const drawn = state.cube.state.mirror()
+        const fromScramble = new CubieCube().apply(shownSetup)
+        for (let j = 0; j < 12; j++) {
+            if (shownMask.ep[j]) expect(drawn.ep.indexOf(j)).toBe(fromScramble.ep.indexOf(j))
+        }
+    }
+})
+
+test('fb mode, left-handed: a pasted left-handed scramble is used verbatim', () => {
+    let state = lefty(getInitialState("fb"))
+    const scramble = "L' U2 L U' M2 U L2 F'"
+    state = reducer(state, { type: "scrambleInput", content: [scramble] })
+    state = reducer(state, { type: "key", content: "#space" })
+
+    expect(mirrorAlg(state.case.desc[0].setup!).trim()).toBe(new MoveSeq(scramble).toString().trim())
+    expect(state.cube.state.serialize()).toBe(new CubieCube().apply(new MoveSeq(scramble).mirror()).serialize())
+})
+
+test('right-handed mode is untouched', () => {
+    let state = getInitialState("fb")
+    state = reducer(state, { type: "config", content: {
+        handednessSelector: state.config.handednessSelector.setFlags([1, 0])
+    }})
+    expect(isLeftHanded(state.mode, state.config)).toBe(false)
+    state = reducer(state, { type: "key", content: "#space" })
+    for (const alg of state.case.desc[0].algs) {
+        const cube = new CubieCube().apply(state.case.desc[0].setup!).apply(new MoveSeq(alg))
+        expect(CubeUtil.is_solved(cube, Mask.fb_mask)).toBe(true)
+    }
+})
+
+test('ss mode, left-handed: the second block is built on the left', () => {
+    let state = lefty(getInitialState("ss"))
+    state = reducer(state, { type: "config", content: {
+        ssSelector: state.config.ssSelector.setFlags([1, 0, 0])   // Front SS
+    }})
+    state = reducer(state, { type: "key", content: "#space" })
+
+    const shownSetup = mirrorAlg(state.case.desc[0].setup!)
+    const shownMask = mirrorMask(Mask.ss_front_mask)
+    // mirrored front-SS: FB at DR (DFR/DRB, DR/FR/BR) plus the front SS pair (DLF, FL, DL)
+    expect(shownMask.cp).toEqual([0, 0, 0, 0, 1, 0, 1, 1])
+    expect(shownMask.ep).toEqual([0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1])
+
+    for (const alg of state.case.desc[0].algs.map(mirrorAlg)) {
+        const cube = new CubieCube().apply(shownSetup).apply(new MoveSeq(alg))
+        expect([alg, CubeUtil.is_solved(cube, shownMask)]).toEqual([alg, true])
+    }
+})

--- a/src/lib/Mirror.test.tsx
+++ b/src/lib/Mirror.test.tsx
@@ -1,0 +1,79 @@
+import { CubieCube, CubeUtil, Mask, Move, MoveSeq, mirror_alg_string } from './CubeLib'
+import { arrayEqual } from './Math'
+import { CachedSolver } from './CachedSolver'
+
+const eq = (a: CubieCube, b: CubieCube) =>
+    arrayEqual(a.cp, b.cp) && arrayEqual(a.co, b.co) &&
+    arrayEqual(a.ep, b.ep) && arrayEqual(a.eo, b.eo) && arrayEqual(a.tp, b.tp)
+
+const names = Object.keys(Move.all).filter(n => n !== "id")
+
+test('mirror of solved cube is solved', () => {
+    expect(eq(new CubieCube().mirror(), new CubieCube())).toBe(true)
+})
+
+test('mirror is an involution', () => {
+    for (let i = 0; i < 20; i++) {
+        let c = CubeUtil.get_random_with_mask(Mask.empty_mask)
+        expect(eq(c.mirror().mirror(), c)).toBe(true)
+    }
+})
+
+test('mirror is a homomorphism: mirror(C * m) = mirror(C) * mirror(m)', () => {
+    for (let name of names) {
+        let m = Move.all[name]
+        expect(m.mirror()).toBeDefined()
+        for (let i = 0; i < 5; i++) {
+            let c = CubeUtil.get_random_with_mask(Mask.empty_mask)
+            expect([name, eq(c.apply(m).mirror(), c.mirror().apply(m.mirror()))]).toEqual([name, true])
+        }
+    }
+})
+
+test('mirror maps a solved FB to a solved right-hand block', () => {
+    for (let i = 0; i < 20; i++) {
+        let c = CubeUtil.get_random_with_mask(Mask.fb_mask)
+        expect(CubeUtil.is_solved(c, Mask.fb_mask)).toBe(true)
+        expect(CubeUtil.is_solved(c.mirror(), Mask.mirror(Mask.fb_mask))).toBe(true)
+    }
+})
+
+test('a mirrored scramble produces the mirrored state', () => {
+    for (let i = 0; i < 20; i++) {
+        let seq = new MoveSeq(Array(15).fill(0).map(() => Move.all[names[(Math.random() * names.length) | 0]]))
+        let a = new CubieCube().apply(seq).mirror()
+        let b = new CubieCube().apply(seq.mirror())
+        expect(eq(a, b)).toBe(true)
+    }
+})
+
+test('mirror_alg_string leaves non-move text alone', () => {
+    expect(mirror_alg_string("(x) R U R' M2 r' (7)")).toBe("(x) L' U' L M2 l (7)")
+})
+
+test('a left-handed user can follow the mirrored scramble and solution', () => {
+    const solver = CachedSolver.get("fb")
+    for (let i = 0; i < 3; i++) {
+        const cube = CubeUtil.get_random_with_mask(Mask.empty_mask)
+        const sol = solver.solve(cube, 0, 11, 1)[0]
+        expect(CubeUtil.is_solved(cube.apply(sol), Mask.fb_mask)).toBe(true)
+
+        // what the app hands a left-handed user: the mirrored state, and the
+        // solution mirrored the same way
+        const lefty_cube = cube.mirror()
+        const solution = mirror_alg_string(sol.toString())
+        expect(CubeUtil.is_solved(lefty_cube.apply(solution), Mask.mirror(Mask.fb_mask))).toBe(true)
+
+        // a scramble shown left-handed reproduces the state shown left-handed
+        const setup = sol.inv()
+        expect(eq(new CubieCube().apply(mirror_alg_string(setup.toString())),
+                  new CubieCube().apply(setup).mirror())).toBe(true)
+    }
+    // the mirrored FB mask is the right-hand block: DFR/DRB corners, DR/FR/BR edges, R center
+    expect(Mask.mirror(Mask.fb_mask)).toEqual({
+        co: undefined, eo: undefined,
+        cp: [0, 0, 0, 0, 0, 0, 1, 1],
+        ep: [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1],
+        tp: [0, 0, 0, 0, 1, 1]
+    })
+})

--- a/src/reducers/BlockTrainerStateM.tsx
+++ b/src/reducers/BlockTrainerStateM.tsx
@@ -7,6 +7,7 @@ import { CachedSolver } from "../lib/CachedSolver";
 import { rand_choice, arrayEqual } from '../lib/Math';
 import { AbstractStateM, StateFactory } from "./AbstractStateM";
 import { Config } from "../Config";
+import { isLeftHanded, mirrorScramble } from "../lib/Handedness";
 
 type RandomCubeT = {
     cube: CubieCube,
@@ -173,7 +174,9 @@ export abstract class BlockTrainerStateM extends AbstractStateM {
         let {cube, solvers: solverNames, ssolver: scrambleSolver, failed} = this.getRandom();
         let inputScramble : string | undefined = undefined
         if (this.state.scrambleInput.length > 0) {
-            inputScramble = this.state.scrambleInput[0]
+            inputScramble = isLeftHanded(this.state.mode, this.state.config)
+                ? mirrorScramble(this.state.scrambleInput[0])
+                : this.state.scrambleInput[0]
             cube = new CubieCube().apply(inputScramble)
         }
         let state = this._solve(cube, solverNames, {


### PR DESCRIPTION
I opened [this issue](https://github.com/onionhoney/roux-trainers/issues/14) a couple years ago but now that I'm smarter ( :laughing: ) I was able to figure it out what I needed to do this on my own

---

Screenshots

"Handedness" picker, which is right-handed by default

<img width="441" height="386" alt="image" src="https://github.com/user-attachments/assets/c78eb17f-c4a3-4036-8f39-8015d8d6ff73" />


Right Block as FB :)
<img width="590" height="396" alt="image" src="https://github.com/user-attachments/assets/2447b57e-0b2b-4124-9b57-4ee76ab9d4b5" />


Left Block as SB

<img width="415" height="366" alt="image" src="https://github.com/user-attachments/assets/fd4e59e5-d65e-4198-9ddf-0558d6ecf469" />

---

closes https://github.com/onionhoney/roux-trainers/issues/14)